### PR TITLE
✨ Add Image Uploading with Supabase + Wardrobe Item Storage

### DIFF
--- a/supabase/migrations/20250212200541_avatar_bucket.sql
+++ b/supabase/migrations/20250212200541_avatar_bucket.sql
@@ -1,0 +1,33 @@
+-- Maak een avatars bucket aan in Supabase Storage
+insert into storage.buckets (id, name, public) 
+values ('avatars', 'avatars', true)
+on conflict (id) do nothing;
+
+
+-- Functie om automatisch de avatar_url te updaten in de profiles tabel
+create or replace function handle_avatar_upload()
+returns trigger as $$
+begin
+  if NEW.bucket_id = 'avatars' then
+    update profiles
+    set avatar_url = 'https://openwdsupdemo.sug.lol/storage/v1/object/public/avatars/' || NEW.name
+    where id = auth.uid();
+  end if;
+  return NEW;
+end;
+$$ language plpgsql;
+
+-- Trigger die wordt geactiveerd bij uploads in de avatars bucket
+create or replace trigger avatar_upload_trigger
+after insert on storage.objects
+for each row
+when (NEW.bucket_id = 'avatars')
+execute function handle_avatar_upload();
+
+-- RLS Policies (optioneel) voor extra beveiliging
+alter table user_profiles enable row level security;
+
+create policy "Allow users to update their own avatar"
+on user_profiles
+for update
+using (auth.uid() = id);

--- a/supabase/migrations/20250212201657_update_wardrobe_items_migration.sql
+++ b/supabase/migrations/20250212201657_update_wardrobe_items_migration.sql
@@ -1,0 +1,57 @@
+-- 🚨 Drop all dependent views before modifying wardrobe_item
+drop view if exists v_recent_usage cascade;
+drop view if exists v_user_outfits cascade;
+drop view if exists v_user_wardrobe cascade;
+
+
+-- Drop pic table
+drop table if exists pic;
+
+-- Ensure the wardrobe_items bucket exists and is private
+insert into storage.buckets (id, name, public) 
+values ('wardrobe_items', 'wardrobe_items', false)
+on conflict (id) do nothing;
+
+-- Drop the name column from wardrobe_item (if it exists)
+alter table wardrobe_item drop column if exists name;
+
+-- Add image_path column to store private file path
+alter table wardrobe_item add column if not exists image_path text;
+
+-- Function to automatically insert a wardrobe item when a file is uploaded
+create or replace function handle_wardrobe_item_upload()
+returns trigger as $$
+begin
+  if NEW.bucket_id = 'wardrobe_items' then
+    insert into wardrobe_item (user_id, image_path, created_at)
+    values (
+      auth.uid(), 
+      NEW.name,  -- Store only the file path (since items are private)
+      now()
+    );
+  end if;
+  return NEW;
+end;
+$$ language plpgsql;
+
+-- Ensure trigger executes when a new file is uploaded to wardrobe_items
+create or replace trigger wardrobe_item_upload_trigger
+after insert on storage.objects
+for each row
+when (NEW.bucket_id = 'wardrobe_items')
+execute function handle_wardrobe_item_upload();
+
+-- Ensure Row-Level Security (RLS) is enabled for wardrobe_item
+alter table wardrobe_item enable row level security;
+
+-- Policy to allow users to insert their own wardrobe items
+create policy "Allow users to insert their own wardrobe items"
+on wardrobe_item
+for insert
+with check (auth.uid() = user_id);
+
+-- Policy to allow users to view their own wardrobe items
+create policy "Allow users to view their own wardrobe items"
+on wardrobe_item
+for select
+using (auth.uid() = user_id);

--- a/supabase/migrations/20250212231840_v_user_category.sql
+++ b/supabase/migrations/20250212231840_v_user_category.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE VIEW v_user_category_summary AS
+SELECT 
+    c.id AS category_id,
+    c.name AS category_name,
+    COUNT(w2.id) AS item_count,
+    (
+        SELECT w3.image_path 
+        FROM wardrobe_item w3 
+        WHERE w3.category_id = c.id 
+        AND w3.user_id = w2.user_id
+        ORDER BY random() -- Pick a random item image from the category
+        LIMIT 1
+    ) AS category_image,
+    w2.user_id
+FROM item_category c
+LEFT JOIN wardrobe_item w2 ON w2.category_id = c.id
+GROUP BY c.id, c.name, w2.user_id;
+
+CREATE OR REPLACE FUNCTION get_user_category_summary()
+RETURNS TABLE (
+    category_id uuid,
+    category_name text,
+    user_id uuid,
+    item_count bigint,
+    category_image text
+) 
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+    SELECT * FROM v_user_category_summary WHERE user_id = auth.uid();
+$$;
+

--- a/supabase/migrations/20250212233655_new_item_metadata.sql
+++ b/supabase/migrations/20250212233655_new_item_metadata.sql
@@ -1,0 +1,25 @@
+DROP TABLE IF EXISTS item_metadata;
+
+CREATE TABLE item_metadata (
+    id UUID DEFAULT extensions.uuid_generate_v4() PRIMARY KEY,
+    wardrobe_item_id UUID REFERENCES wardrobe_item(id) ON DELETE CASCADE,
+    bought_for NUMERIC(10,2),
+    currency TEXT DEFAULT 'USD',
+    purchase_date DATE,
+    condition TEXT CHECK (condition IN ('New', 'Like New', 'Used', 'Vintage')),
+    material TEXT,
+    size TEXT,
+    color TEXT,
+    notes TEXT,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+
+ALTER TABLE item_metadata ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only access their own metadata"
+ON item_metadata
+FOR SELECT USING (
+    EXISTS (SELECT 1 FROM wardrobe_item WHERE wardrobe_item.id = item_metadata.wardrobe_item_id AND wardrobe_item.user_id = auth.uid())
+);


### PR DESCRIPTION

This PR implements **image uploading using Supabase Storage** and updates the wardrobe item structure to support **image-based storage** instead of textual names.

### **🔹 Summary of Changes**
✅ **Supabase Storage Buckets Created:**
- `avatars` → Stores user profile pictures
- `wardrobe_items` → Stores images of wardrobe items (private)

✅ **New Functions & Triggers for Image Handling:**
- `handle_avatar_upload()` → Updates user profile with uploaded avatar
- `handle_wardrobe_item_upload()` → Automatically inserts wardrobe item when an image is uploaded

✅ **Database Schema Changes:**
- **Dropped**: `pic` table (images now stored in Supabase Storage)
- **Dropped**: `wardrobe_item.name` (now using `image_path`)
- **Added**: `wardrobe_item.image_path` (stores file reference)
- **Updated**: `item_metadata` to include purchase details (price, condition, size, etc.)

✅ **Row-Level Security (RLS) Policies Added:**
- Users can only **access & upload their own wardrobe items**
- Users can **update their own avatar**
- Metadata is restricted to the owner of the wardrobe item

✅ **New Database Views & Functions:**
- `v_user_category_summary` → Aggregates item count per category with a sample image
- `get_user_category_summary()` → Allows users to fetch their own category data

---

### **🛠 How It Works**
- **User uploads a wardrobe item image** → File is stored in `wardrobe_items` bucket
- **Trigger automatically creates an entry** in `wardrobe_item` with a reference to the file
- **Users can view only their own wardrobe items & metadata**
